### PR TITLE
Explicitly enable SO_BROADCAST for DatagramSocket

### DIFF
--- a/src/main/java/de/sciss/net/OSCTransmitter.java
+++ b/src/main/java/de/sciss/net/OSCTransmitter.java
@@ -38,6 +38,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
@@ -650,7 +651,19 @@ implements OSCChannel
 				if( dch == null ) {
 					final DatagramChannel newCh = DatagramChannel.open();
 					newCh.socket().bind( localAddress );
-					newCh.socket().setBroadcast( true );
+
+					// Some systems, explicitly Android 7, don't enable SO_BROADCAST by default
+					// for sockets created by DatagramChannel.open(). SO_BROADCAST is needed for
+					// sending a message to a broadcast address.
+                                        // We check if it's enabled and  try to set it manually if otherwise.
+					if (!newCh.socket().getBroadcast()) {
+						try {
+							newCh.socket().setBroadcast( true );
+						} catch ( SocketException e ) {
+							// No further action required.
+							// We just can't send broadcast messages.
+						}
+					}
 					dch = newCh;
 				}
 			}

--- a/src/main/java/de/sciss/net/OSCTransmitter.java
+++ b/src/main/java/de/sciss/net/OSCTransmitter.java
@@ -650,6 +650,7 @@ implements OSCChannel
 				if( dch == null ) {
 					final DatagramChannel newCh = DatagramChannel.open();
 					newCh.socket().bind( localAddress );
+					newCh.socket().setBroadcast( true );
 					dch = newCh;
 				}
 			}


### PR DESCRIPTION
Seemingly Android 7 changed Android's former default behaviour and does not
enable SO_BROADCAST anymore. Trying to send a OSC message to a broadcast address
results in a  java.net.SocketException: Permission denied, see
https://github.com/Sciss/NetUtil/issues/4 .

Explicitly enabling SO_BROADCAST fixes this issue.